### PR TITLE
Add build-time env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /app
 
 ENV PATH /app/node_modules/.bin:$PATH
 
+# https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#setting-build-time-environment-variables
+ARG REACT_APP_SET_AUTH
+ARG REACT_APP_TOKEN_ENDPOINT
+
 COPY package.json ./
 COPY package-lock.json ./
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,3 +1,6 @@
 build:
   docker:
     web: Dockerfile
+  config:
+    REACT_APP_SET_AUTH: roomcode
+    REACT_APP_TOKEN_ENDPOINT: https://api.waveformhealth.com/v1/token


### PR DESCRIPTION
We need to set environment variable in order to configure our
app to run as expected. We specifically need to set
REACT_APP_SET_AUTH and REACT_APP_TOKEN_ENDPOINT.

Heroku's "config vars" are not readable at build time, but
we can use their build time env var setting in heroku.yml. This
does require setting ARGs in our dockerfile.

See: https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#setting-build-time-environment-variables